### PR TITLE
Adding module imports

### DIFF
--- a/chompchange/__init__.py
+++ b/chompchange/__init__.py
@@ -1,0 +1,3 @@
+from .block import *
+from .transaction import *
+from .chain import *


### PR DESCRIPTION
This adds module `import`s so that we can actually _use_ the chain primitives.